### PR TITLE
Janky global-suspense implementation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from "./reconciler";
 export * from "./renderer";
 export * from "./types";
 export * from "./utils/debounceAsync";
+export * from "./utils/GlobalSuspense";

--- a/src/intrinsics/elements/index.ts
+++ b/src/intrinsics/elements/index.ts
@@ -4,6 +4,8 @@ import type { UnfurledMediaResolvable } from "./base";
 import type { SelectProps } from "./select";
 import type { ButtonProps } from "./button";
 
+export const globalSuspense = '$$globalSuspense';
+
 export interface DJSXElements {
     // main elements
     message: PropsWithChildren<{

--- a/src/payload/index.ts
+++ b/src/payload/index.ts
@@ -3,6 +3,7 @@ import type { InternalNode } from "../reconciler/types";
 import { v4 } from "uuid";
 import type { DJSXEventHandlerMap } from "src/types/events";
 import { InteractionMessageFlags, MessagePayloadOutput, ModalPayloadOutput } from "./types";
+import { globalSuspense } from "src/intrinsics/elements";
 
 type InstrinsicNodesMap = {
     [K in keyof React.JSX.IntrinsicElements]: {
@@ -33,7 +34,8 @@ export class PayloadBuilder {
         return node.children.map(this.getText.bind(this)).join("");
     }
 
-    createMessage(node: InternalNode): MessagePayloadOutput {
+    createMessage(node: InternalNode): MessagePayloadOutput | { suspended: true } {
+        if (node.type === globalSuspense) return { suspended: true };
         if (node.type !== "message") throw new Error("Element isn't <message>");
 
         let flags: InteractionMessageFlags[] = [];

--- a/src/payload/types.ts
+++ b/src/payload/types.ts
@@ -7,6 +7,7 @@ export type InteractionMessageFlags = MessageFlags.Ephemeral
     | MessageFlags.IsComponentsV2;
 
 export type MessagePayloadOutput = {
+    suspended?: false;
     payload: BaseMessageOptions;
     flags: InteractionMessageFlags[];
     eventHandlers: Pick<DJSXEventHandlerMap, "button" | "select">;

--- a/src/reconciler/HostConfig.ts
+++ b/src/reconciler/HostConfig.ts
@@ -95,6 +95,8 @@ export const InternalHostConfig: HostConfig<
     getInstanceFromScope: () => null,
     // @ts-ignore
     maySuspendCommit: () => false,
+    startSuspendingCommit: () => {},
+    waitForCommitToBeReady: () => null,
 
     resetFormInstance() {},
     setCurrentUpdatePriority: (newPriority: number) => {},

--- a/src/renderer/index.ts
+++ b/src/renderer/index.ts
@@ -9,6 +9,7 @@ import { PayloadBuilder } from "src/payload";
 import { MessagePayloadOutput } from "src/payload/types";
 import { DJSXRendererEventMap } from "./types";
 import { v4 } from "uuid";
+import { inspect } from "node:util";
 
 export class DJSXRenderer extends (EventEmitter as new () => TypedEventEmitter<DJSXRendererEventMap>) {
     key?: string = v4();
@@ -94,6 +95,9 @@ export class DJSXRenderer extends (EventEmitter as new () => TypedEventEmitter<D
         try {
             let payload = new PayloadBuilder(this.prefixCustomId.bind(this))
                 .createMessage(container.node);
+            if ('suspended' in payload && payload.suspended) {
+                return;
+            }
             this.events = payload.eventHandlers;
             this.updateMessageDebounced(payload);
         } catch (e) {
@@ -167,6 +171,7 @@ export class DJSXRenderer extends (EventEmitter as new () => TypedEventEmitter<D
         } catch (e) {
             this.emit("fatalError", e as Error);
             console.log("[discordjsx/renderer] (fatal) Error", e);
+            console.log(inspect(e.requestBody.json.data, { depth: Infinity }))
         }
     }
 }

--- a/src/utils/GlobalSuspense.tsx
+++ b/src/utils/GlobalSuspense.tsx
@@ -1,0 +1,7 @@
+import { Suspense } from "react";
+import { jsx } from "react/jsx-runtime";
+import { globalSuspense } from "src/intrinsics/elements";
+
+export function GlobalSuspense({ children }: { children: React.ReactNode }) {
+    return <Suspense fallback={jsx(globalSuspense as any, {})}>{children}</Suspense>;
+}


### PR DESCRIPTION
This adds a component, `<GlobalSuspense>`, that when placed at the root (above `<message>`) will create a suspense boundary that does not update the message until all suspended promises finish executing. Essentially it's like `<Suspense>` with no fallback, because displaying a 'Loading...' message is not ideal for bot behavior.