### PR TITLE
Fix inconsistencies between UnfurledMediaResolvable and APIUnfurledMediaItem

### DIFF
--- a/src/intrinsics/elements/index.d.ts
+++ b/src/intrinsics/elements/index.d.ts
@@ -1,4 +1,4 @@
-import type { APIMediaGalleryItem, APISelectMenuOption, ColorResolvable } from "discord.js";
+import type { APIMediaGalleryItem, APISelectMenuOption, ColorResolvable, APIEmbedThumbnail, APIEmbedImage } from "discord.js";
 import type { PropsWithChildren } from "react";
 import type { UnfurledMediaResolvable } from "./base.d.ts";
 import type { SelectProps } from "./select.d.ts";
@@ -47,14 +47,14 @@ export interface DJSXElements {
     thumbnail: {
         description?: string;
         spoiler?: boolean;
-        media?: UnfurledMediaResolvable;
+        media?: APIUnfurledMediaItem | UnfurledMediaResolvable;
     } & React.JSX.IntrinsicAttributes;
 
     gallery: PropsWithChildren & React.JSX.IntrinsicAttributes;
     'gallery-item': APIMediaGalleryItem & React.JSX.IntrinsicAttributes;
 
     file: {
-        file: UnfurledMediaResolvable;
+        file: APIUnfurledMediaItem | UnfurledMediaResolvable;
         spoiler?: boolean;
     } & React.JSX.IntrinsicAttributes;
 

--- a/src/intrinsics/elements/index.d.ts
+++ b/src/intrinsics/elements/index.d.ts
@@ -1,4 +1,4 @@
-import type { APIMediaGalleryItem, APISelectMenuOption, ColorResolvable, APIEmbedThumbnail, APIEmbedImage } from "discord.js";
+import type { APIMediaGalleryItem, APISelectMenuOption, APIUnfurledMediaItem, ColorResolvable, APIEmbedThumbnail, APIEmbedImage } from "discord.js";
 import type { PropsWithChildren } from "react";
 import type { UnfurledMediaResolvable } from "./base.d.ts";
 import type { SelectProps } from "./select.d.ts";

--- a/src/intrinsics/elements/index.d.ts
+++ b/src/intrinsics/elements/index.d.ts
@@ -51,7 +51,11 @@ export interface DJSXElements {
     } & React.JSX.IntrinsicAttributes;
 
     gallery: PropsWithChildren & React.JSX.IntrinsicAttributes;
-    'gallery-item': APIMediaGalleryItem & React.JSX.IntrinsicAttributes;
+    'gallery-item': {
+        media: APIUnfurledMediaItem | UnfurledMediaResolvable;
+        description?: string | null;
+        spoiler?: boolean;
+    } & React.JSX.IntrinsicAttributes;
 
     file: {
         file: APIUnfurledMediaItem | UnfurledMediaResolvable;

--- a/src/payload/index.ts
+++ b/src/payload/index.ts
@@ -131,7 +131,7 @@ export class PayloadBuilder {
 
                 return {
                     type: 11,
-                    media: { url: node.props.media },
+                    media: typeof node.props.media === 'string' ? { url: node.props.media } : node.props.media,
                     description: node.props.description,
                     spoiler: node.props.spoiler,
                 };
@@ -145,22 +145,22 @@ export class PayloadBuilder {
             case "file":
                 return {
                     type: 13,
-                    file: { url: node.props.file },
+                    file: typeof node.props.file === 'string' ? { url: node.props.file } : node.props.file,
                     spoiler: node.props.spoiler,
-                }
+                };
             case "separator":
                 return {
                     type: 14,
                     divider: node.props.divider,
                     spacing: node.props.spacing == "lg" ? 2 : 1,
-                }
+                };
             case "container":
                 return {
                     type: 17,
                     components: this.toDiscordComponentsArray(node.children) as any,
                     accent_color: node.props.color ? resolveColor(node.props.color) : undefined,
                     spoiler: node.props.spoiler,
-                }
+                };
             default:
                 return null;
         }

--- a/src/payload/index.ts
+++ b/src/payload/index.ts
@@ -1,10 +1,12 @@
-import type { APIButtonComponent, APIMediaGalleryItem, APIMessageComponent, APIMessageTopLevelComponent } from "discord.js";
+import type { APIButtonComponent, APIMediaGalleryItem, APIMessageComponent, APIMessageTopLevelComponent, APIUnfurledMediaItem } from "discord.js";
 import { ComponentType, MessageFlags, resolveColor } from "discord.js";
 import type { InternalNode } from "../reconciler/index.js";
 import { v4 } from "uuid";
 import type { DJSXEventHandlerMap } from "../types/index.js";
 import type { MessagePayloadOutput, ModalPayloadOutput } from "./types.js";
 import type { DefaultButtonProps, LinkButtonProps, PremiumButtonProps } from "../intrinsics/elements/button.js";
+import { UnfurledMediaResolvable } from "src/intrinsics/elements/base.js";
+import { DJSXElements } from "src/intrinsics/elements/index.js";
 
 type InstrinsicNodesMap = {
     [K in keyof React.JSX.IntrinsicElements]: {
@@ -140,7 +142,16 @@ export class PayloadBuilder {
 
                 return {
                     type: 12,
-                    items: node.children.map(child => child.props as APIMediaGalleryItem),
+                    items: node.children
+                        .filter(child => child.type === 'gallery-item')
+                        .map(child => {
+                            const props = child.props as DJSXElements['gallery-item'];
+                            return {
+                                media: typeof props.media === 'string' ? { url: props.media } : props.media,
+                                description: props.description,
+                                spoiler: props.spoiler,
+                            };
+                        }),
                 };
             case "file":
                 return {


### PR DESCRIPTION
Previously, `<gallery-item>` demanded APIUnfurledMediaItem and `<thumbnail>` and `<file>` demanded UnfurledMediaResolvable. Now they all accept both.