### PR TITLE
Support emoji short syntax

### DIFF
--- a/src/intrinsics/elements/button.d.ts
+++ b/src/intrinsics/elements/button.d.ts
@@ -5,7 +5,7 @@ import type { DJSXEventHandler } from "../../types/events";
 export interface BaseButtonProps extends BaseInteractableProps {
     disabled?: boolean;
     /** A unicode emoji, or a formatted emoji mention, or an emoji ID, or an emoji object. */
-    emoji?: EmojiResolvable | string;
+    emoji?: EmojiResolvable | APIMessageComponentEmoji | string;
 };
 
 export interface DefaultButtonProps extends BaseButtonProps {

--- a/src/intrinsics/elements/button.d.ts
+++ b/src/intrinsics/elements/button.d.ts
@@ -1,10 +1,11 @@
-import type { APIMessageComponentEmoji, ButtonInteraction } from "discord.js";
+import type { APIMessageComponentEmoji, ButtonInteraction, EmojiResolvable } from "discord.js";
 import type { BaseInteractableProps } from "./base.d.ts";
 import type { DJSXEventHandler } from "../../types/events";
 
 export interface BaseButtonProps extends BaseInteractableProps {
     disabled?: boolean;
-    emoji?: APIMessageComponentEmoji;
+    /** A unicode emoji, or a formatted emoji mention, or an emoji ID, or an emoji object. */
+    emoji?: EmojiResolvable | string;
 };
 
 export interface DefaultButtonProps extends BaseButtonProps {

--- a/src/payload/index.ts
+++ b/src/payload/index.ts
@@ -283,7 +283,7 @@ export class PayloadBuilder {
         };
     }
 
-    private resolveEmoji(emoji: EmojiResolvable | string): APIMessageComponentEmoji {
+    private resolveEmoji(emoji: EmojiResolvable | APIMessageComponentEmoji | string): APIMessageComponentEmoji {
         if (typeof emoji === 'string') {
             // Is formatted emoji
             if (emoji.startsWith('<') && emoji.endsWith('>')) {

--- a/src/payload/index.ts
+++ b/src/payload/index.ts
@@ -287,13 +287,14 @@ export class PayloadBuilder {
         if (typeof emoji === 'string') {
             // Is formatted emoji
             if (emoji.startsWith('<') && emoji.endsWith('>')) {
-                const emojiRe = /<a?:([a-zA-Z0-9_]+):(\d+)>/;
+                const emojiRe = /<(a?):([a-zA-Z0-9_]+):(\d+)>/;
 
                 const match = emoji.match(emojiRe);
                 if (match) {
                     return {
-                        name: match[1],
-                        id: match[2],
+                        name: match[2],
+                        id: match[3],
+                        animated: match[1] === 'a',
                     };
                 }
             }
@@ -311,6 +312,7 @@ export class PayloadBuilder {
         return {
             name: emoji.name ?? undefined,
             id: emoji.id ?? undefined,
+            animated: emoji.animated ?? undefined,
         };
     }
 


### PR DESCRIPTION
Allows you to provide a formatted custom emoji, or a unicode string, or an EmojiResolvable (including a plain emoji ID) for `<button>`'s emoji property. Fixes #7 